### PR TITLE
Fix: prevent calling updater on purged states

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mrnafisia/yasm",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "Yet another state management!",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",

--- a/src/useYasmState.ts
+++ b/src/useYasmState.ts
@@ -162,9 +162,15 @@ const route = <SM extends Record<Name, Section>, N extends keyof SM>(
         path,
         () => store.state[name][path],
         payload =>
-            produce(store.state[name][path], (draft: any) =>
-                store.sectionMap[name].updater(draft, payload)
-            )
+            produce(store.state[name][path], (draft: any) => {
+                // This prevents errors when the updater is triggered asynchronously
+                // (e.g., in a `setTimeout`, `.then`, or other delayed executions) where the state might have been purged already.
+                if (store.state[name][path] === undefined) {
+                    return;
+                }
+
+                return store.sectionMap[name].updater(draft, payload);
+            })
     ];
 };
 

--- a/src/useYasmState.ts
+++ b/src/useYasmState.ts
@@ -289,12 +289,19 @@ const getExtraRoutes = <SM extends Record<Name, Section>, N extends keyof SM>(
                     }
                     return selectedState;
                 },
-                payload =>
-                    updateByPathQuery(
+                payload => {
+                    // This prevents errors when the updater is triggered asynchronously
+                    // (e.g., in a `setTimeout`, `.then`, or other delayed executions) where the state might have been purged already.
+                    if (store.state[name][foundPath] === undefined) {
+                        return;
+                    }
+
+                    return updateByPathQuery(
                         store.state[name][foundPath],
                         pathQuery,
                         payload
-                    )
+                    );
+                }
             ];
         }
         const routingInfo = getExtraRoutes(store, [name, ...names], path);


### PR DESCRIPTION
Prevent the updater function from being called on a purged state by adding an `undefined` check. This avoids potential errors when the updater is triggered asynchronously (e.g., in `setTimeout`, `.then`, or other delayed executions) where the state might have already been cleared.

