### PR TITLE
add support for function form of `overrideInitialState` to access `initialState`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mrnafisia/yasm",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "Yet another state management!",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mrnafisia/yasm",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "description": "Yet another state management!",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",

--- a/src/useYasmState.ts
+++ b/src/useYasmState.ts
@@ -162,9 +162,15 @@ const route = <SM extends Record<Name, Section>, N extends keyof SM>(
         path,
         () => store.state[name][path],
         payload =>
-            produce(store.state[name][path], (draft: any) =>
-                store.sectionMap[name].updater(draft, payload)
-            )
+            produce(store.state[name][path], (draft: any) => {
+                // This prevents errors when the updater is triggered asynchronously
+                // (e.g., in a `setTimeout`, `.then`, or other delayed executions) where the state might have been purged already.
+                if (store.state[name][path] === undefined) {
+                    return;
+                }
+
+                return store.sectionMap[name].updater(draft, payload);
+            })
     ];
 };
 

--- a/src/useYasmState.ts
+++ b/src/useYasmState.ts
@@ -289,12 +289,19 @@ const getExtraRoutes = <SM extends Record<Name, Section>, N extends keyof SM>(
                     }
                     return selectedState;
                 },
-                payload =>
-                    updateByPathQuery(
+                payload => {
+                    // This prevents errors when the updater is triggered asynchronously
+                    // (e.g., in a `setTimeout`, `.then`, or other delayed executions) where the state might have been purged already.
+                    if (store.state[name][foundPath] === undefined) {
+                        return;
+                    }
+
+                    return updateByPathQuery(
                         store.state[name][foundPath],
                         pathQuery,
                         payload
-                    )
+                    );
+                }
             ];
         }
         const routingInfo = getExtraRoutes(store, [name, ...names], path);


### PR DESCRIPTION
Added support for `overrideInitialState` as a function that receives the `initialState` and returns a partial state.

The `useAppState`:
```ts
import { useYasmState } from '@mrnafisia/yasm';

import { store } from './index';

type SectionMap = typeof store.sectionMap;

type Updater<Name extends keyof SectionMap> = (
    payload:
        | Parameters<SectionMap[Name]['updater']>[1]
        | ((
              state: SectionMap[Name]['initialState']
          ) => Parameters<SectionMap[Name]['updater']>[1])
) => SectionMap[Name]['initialState'] | void;

type OverrideInitialState<Name extends keyof SectionMap> =
    | Partial<SectionMap[Name]['initialState']>
    | ((
          initialState: SectionMap[Name]['initialState']
      ) => Partial<SectionMap[Name]['initialState']>);

// Overload 1: Basic use (no selector) or use with a selector
function useAppState<Name extends keyof SectionMap, State>(
    name: Name,
    path: string,
    selector?: (state: SectionMap[Name]['initialState']) => State
): [
    unknown extends State ? SectionMap[Name]['initialState'] : State,
    Updater<Name>
];

// Overload 2: Use with options object (selector and/or overrideInitialState)
function useAppState<Name extends keyof SectionMap, State>(
    name: Name,
    path: string,
    options: {
        selector?: (state: SectionMap[Name]['initialState']) => State;
        overrideInitialState?: OverrideInitialState<Name>;
    }
): [
    unknown extends State ? SectionMap[Name]['initialState'] : State,
    Updater<Name>
];

function useAppState<Name extends keyof SectionMap, State>(
    name: Name,
    path: string,
    thirdParam?:
        | ((state: SectionMap[Name]['initialState']) => State)
        | {
              selector?: (state: SectionMap[Name]['initialState']) => State;
              overrideInitialState?: OverrideInitialState<Name>;
          }
) {
    return useYasmState(
        name,
        path,
        thirdParam as Parameters<typeof useYasmState>[2]
    ) as [
        unknown extends State ? SectionMap[Name]['initialState'] : State,
        Updater<Name>
    ];
}
```