### PR TITLE
Fix: prevent calling the updater (callback updater) on purged states

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mrnafisia/yasm",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "Yet another state management!",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",


### PR DESCRIPTION
Prevent the updater function's "callback" from being called on a purged state by adding an `undefined` check. This avoids potential errors when the updater is triggered asynchronously (e.g., in setTimeout, .then, or other delayed executions) where the state might have already been cleared.

Currently, the updater runs regardless of whether the state exists:
```ts
fetchData().then(result =>
    updateState(prev => ({ data: prev.flag ? result : prev.data }))
);
```
If the state is purged before the promise resolves, `prev` becomes `undefined`, leading to an error:
`Cannot read properties of undefined (reading 'flag')`

If the state is already purged, `prev => ({ data: prev.flag ? result : prev.data })` must not be called at all!