### PR TITLE
Fix: prevent crash when removing the subscribers of a purged state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mrnafisia/yasm",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "description": "Yet another state management!",
     "main": "./dist/index.umd.js",
     "module": "./dist/index.es.js",

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -105,6 +105,17 @@ const createStore = <SM extends Record<Name, Section>>(
                 };
             }
             return () => {
+                if (subscribers[name]?.[path]?.[id] === undefined) {
+                    console.warn(
+                        [
+                            `YASM [Warning]: The state of "${name.toString()}" at path "${path}" has been purged before its dependent components were unmounted!`,
+                            `(Dependent components are those that read and use this state.)`,
+                            `Ensure that the purge action occurs at the right time (when all dependent components are unmounted) by using "useEffect" or "setTimeout" to prevent premature state purging.`
+                        ].join('\n')
+                    );
+                    return;
+                }
+
                 delete subscribers[name][path][id];
             };
         },


### PR DESCRIPTION
This fix prevents `Uncaught TypeError: Cannot convert undefined or null to object` when removing the subscribers of a purged state (`*`):

```ts
subscribe: (callback, name, path) => {
    const id = counter++;
    if (subscribers[name][path] !== undefined) {
        subscribers[name][path][id] = callback;
    } else {
        (subscribers[name] as Record<Path, Record<number, () => void>>)[
            path
        ] = {
            [id]: callback
        };
    }
    return () => {
        delete subscribers[name][path][id];  // *
    };
},
```